### PR TITLE
feature. Icon, TextField 수정 및 테스트 코드 작성

### DIFF
--- a/__tests__/components/icon/KIcon.test.tsx
+++ b/__tests__/components/icon/KIcon.test.tsx
@@ -20,7 +20,7 @@ describe('KButton', () => {
 
       const testStyle = { color: 'red', fontSize: '20px' };
       render(<KIcon icon='search' style={testStyle} />);
-      const root = screen.getByRole('button');
+      const root = screen.getByRole('img');
 
       expect(root).toHaveStyle(testStyle);
     });
@@ -29,7 +29,7 @@ describe('KButton', () => {
 
       const testClass = 'test-class-name';
       render(<KIcon icon='search' className={testClass} />);
-      const root = screen.getByRole('button');
+      const root = screen.getByRole('img');
 
       expect(root).toHaveClass(testClass);
     });
@@ -38,7 +38,7 @@ describe('KButton', () => {
 
       const testSize = 77;
       render(<KIcon icon='search' size={testSize} />);
-      const root = screen.getByRole('button');
+      const root = screen.getByRole('img');
 
       expect(root).toHaveStyle({ fontSize: `${testSize}px` });
     });
@@ -46,7 +46,7 @@ describe('KButton', () => {
     test('Clickable prop render test', () => {
 
       render(<KIcon icon='search' clickable />);
-      const root = screen.getByRole('button');
+      const root = screen.getByRole('img');
 
       expect(root).toHaveClass('k-icon--clickable');
     });
@@ -55,9 +55,25 @@ describe('KButton', () => {
 
       const testColor = '#eaeaea';
       render(<KIcon icon='search' color={testColor} />);
-      const root = screen.getByRole('button');
+      const root = screen.getByRole('img');
 
       expect(root).toHaveStyle({ color: testColor });
+    });
+
+    test('클릭 이벤트가 있을 때 role이 button으로 적용 된다.', async () => {
+
+      render(<KIcon icon='search' onClick={mockOnClick} />);
+      const root = screen.getByRole('button');
+
+      expect(root).toBeInTheDocument();
+    });
+
+    test('클릭 이벤트가 없을 때 role 이 img 로 적용 된다.', async () => {
+
+      render(<KIcon icon='search' />);
+      const root = screen.getByRole('img');
+
+      expect(root).toBeInTheDocument();
     });
 
 

--- a/__tests__/components/input/text-field/KTextField.test.tsx
+++ b/__tests__/components/input/text-field/KTextField.test.tsx
@@ -7,21 +7,10 @@ import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import { KTextField } from '@/components';
 
-const mockOnClick = jest.fn();
-
-// jest.mock('@/common/util/color', () => ({
-//   tintColor: jest.fn(() => 'red'),
-// }));
 
 const testId = 'k-text-field';
 
 describe('KTextField', () => {
-
-
-  beforeEach(() => {
-    mockOnClick.mockClear();
-  });
-
 
   test('style, value, className prop render test', () => {
 
@@ -31,15 +20,73 @@ describe('KTextField', () => {
 
     render(<KTextField value={testValue} className={testClass} style={testStyle} />);
     const root = screen.getByTestId(testId);
-    const rootInput = screen.getByRole('textbox');
+    const inputRoot = screen.getByRole('textbox');
 
     expect(root).toHaveStyle(testStyle);
     expect(root).toHaveClass(testClass);
-    expect(rootInput).toHaveValue(testValue);
+    expect(inputRoot).toHaveValue(testValue);
+  });
+
+  test('Disabled prop render test', () => {
+
+    render(<KTextField value='' disabled />);
+    const inputRoot = screen.getByRole('textbox') as HTMLInputElement;
+    const root = screen.getByTestId(testId);
+
+    expect(root).toHaveClass('k-text-field--disabled');
+    expect(inputRoot.disabled).toBeTruthy();
+
+  });
+
+  test('placeholder, clearable prop render test', () => {
+
+    const testPlaceholder = 'test placeholder';
+    render(<KTextField value='test' label='test' placeholder={testPlaceholder} clearable />);
+
+    const inputRoot = screen.getByRole('textbox');
+    const clearIcon = screen.getByRole('button');
+
+    expect(inputRoot).toHaveAttribute('placeholder', testPlaceholder);
+    expect(clearIcon).toBeInTheDocument();
+  });
+
+  test('Password prop render test', async () => {
+
+    // Arrange
+    const user = userEvent.setup();
+    const passwordText = 'thisISpassword!';
+    const TestTextField = () => {
+      const [value, setValue] = useState<string>('');
+      return (<KTextField value={value} onChange={(e) => { setValue(e); }} password />);
+    };
+    render(<TestTextField />);
+
+    const inputRoot = screen.getByTestId('k-text-field-input');
+    const visibilityIcon = screen.getByRole('button');
+
+    // Act
+    await act(async () => {
+      await user.click(inputRoot);
+      await user.keyboard(passwordText);
+    });
+
+    // Assert
+    expect(inputRoot).toHaveAttribute('type', 'password');
+
+    // Act
+    await act(async () => {
+      await user.click(visibilityIcon);
+    });
+
+    // Assert
+    expect(inputRoot).toHaveAttribute('type', 'input');
+    expect(inputRoot).toHaveValue(passwordText);
+
   });
 
   test('MaxLength prop render test', async () => {
 
+    // Arrange
     const user = userEvent.setup();
     const testText = 'Hello World! 123';
     const testMaxLength = 10;
@@ -56,9 +103,35 @@ describe('KTextField', () => {
       await user.keyboard(testText);
     });
 
+    // Arrange
     const typedInputRoot = screen.getByRole('textbox');
 
+    // Assert
     expect(typedInputRoot).toHaveValue(testText.substring(0, testMaxLength));
+  });
+
+  test('RightAction prop render test', async () => {
+
+    // Arrange
+    const onMockChange = jest.fn();
+    const rightActionTestId = 'test-right-action-id';
+    const RightAction = () => (<div data-testid={rightActionTestId}>Right Action Text</div>);
+    render(<KTextField label='label' value='' onChange={onMockChange} rightAction={<RightAction />} />);
+    const rightActionRoot = screen.getByTestId(rightActionTestId);
+
+    // Assert
+    expect(rightActionRoot).toBeInTheDocument();
+  });
+
+  test('Width prop render test', async () => {
+
+    // Arrange
+    const testWidth = '321px';
+    render(<KTextField label='label' value='' width={testWidth} />);
+    const inputRoot = screen.getByTestId(testId);
+
+    // Assert
+    expect(inputRoot).toHaveStyle({ width: testWidth });
   });
 
 });

--- a/src/components/icon/KIcon.tsx
+++ b/src/components/icon/KIcon.tsx
@@ -1,7 +1,7 @@
-import {
-  CSSProperties, forwardRef, memo, Ref, useCallback, useId, useImperativeHandle,
-  useMemo, useRef, KeyboardEvent,
-} from 'react';
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+import { CSSProperties, forwardRef, KeyboardEvent, memo, Ref, useCallback,
+  useId, useImperativeHandle, useMemo, useRef } from 'react';
 import { KIconProps, KIconRefs } from '@/components/icon/KIcon.interface';
 import { initDisabled } from '@/common/util/variation';
 import { getIdentityName } from '@/common/base/base';
@@ -86,8 +86,8 @@ const KIcon = forwardRef((props: KIconProps, ref: Ref<KIconRefs>) => {
         data-testid='k-icon'
         onClick={onClick}
         onKeyDown={onKeyDown}
-        role='button'
-        tabIndex={0}
+        role={props.onClick ? 'button' : 'img'}
+        tabIndex={props.onClick ? 0 : -1}
     >
       {props.icon}
     </span>

--- a/src/components/textfield/KTextField.interface.ts
+++ b/src/components/textfield/KTextField.interface.ts
@@ -7,31 +7,37 @@ type LabelDirectionType = typeof labelDirection[keyof typeof labelDirection];
 
 export interface KTextFieldProps extends KBaseProp, KSizeProp {
 
+  // Value
   value: string
 
+  // Label
   label?: string
   labelDirection?: LabelDirectionType
   column?: boolean
   row?: boolean
 
-  disabled?: boolean
+  // Options
   placeholder?: string
   maxLength?: number
+
+  // Types
+  disabled?: boolean
   required?: boolean
   clearable?: boolean
+  password?: boolean
 
+  // Custom
   rightAction?: ReactNode
 
+  // Event
   onChange?: (value: string) => void
   onFocus?: () => void
   onBlur?: () => void
   onKeyDown?: (e?: KeyboardEvent<HTMLInputElement>) => void
   onKeyUp?: (e?: KeyboardEvent<HTMLInputElement>) => void
 
-  color?: string
+  // Styles
   width?: string
-
-  password?: boolean
 }
 
 export interface KTextFieldRefs {

--- a/src/components/textfield/KTextField.interface.ts
+++ b/src/components/textfield/KTextField.interface.ts
@@ -18,6 +18,7 @@ export interface KTextFieldProps extends KBaseProp, KSizeProp {
   placeholder?: string
   maxLength?: number
   required?: boolean
+  clearable?: boolean
 
   rightAction?: ReactNode
 

--- a/src/components/textfield/KTextField.tsx
+++ b/src/components/textfield/KTextField.tsx
@@ -60,14 +60,10 @@ const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>)
 
     const styles: CSSProperties = props.style || {};
 
-    if (props.color) {
-      styles.color = props.color;
-      styles.borderColor = props.color;
-    }
     if (props.width) { styles.width = props.width; }
 
     return styles;
-  }, [props.style, props.color]);
+  }, [props.style]);
 
   const labelClass = useMemo(() => {
     const clazz = [];
@@ -157,6 +153,7 @@ const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>)
                     disabled={props.disabled}
                     placeholder={props.placeholder}
                     maxLength={props.maxLength}
+                    data-testid='k-text-field-input'
                     // aria-describedby='message' // FIXME: Error Message - 웹접근성
         />
         {

--- a/src/components/textfield/KTextField.tsx
+++ b/src/components/textfield/KTextField.tsx
@@ -1,17 +1,19 @@
-import { ChangeEvent, CSSProperties, forwardRef, memo, Ref, useCallback,
-  useId, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import {
+  ChangeEvent, CSSProperties, forwardRef, memo, Ref, useCallback,
+  useId, useImperativeHandle, useMemo, useRef, useState,
+} from 'react';
 import { KTextFieldProps, KTextFieldRefs } from '@/components/textfield/KTextField.interface';
 import { initDisabled, initSize } from '@/common/util/variation';
-import { getIdentityName } from '@/common/base/base';
+import { KIcon } from '@/components';
 
-const identity = getIdentityName('text-field');
 
 const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>) => {
 
   // region [Hooks]
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const uniqueId = `${useId()}-${identity}-input`;
+  const uniqueId = `k-text-field-input-${useId()}`;
+  const [isPasswdShow, setIsPasswdShow] = useState<boolean>(false);
   const [isFocus, setIsFocus] = useState<boolean>(false);
 
   useImperativeHandle(ref, () => ({
@@ -27,25 +29,26 @@ const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>)
   // region [Styles]
 
   const rootClass = useMemo(() => {
-    const clazz = [identity];
+    const clazz = [];
 
     if (props.className) { clazz.push(props.className); }
 
-    initSize(clazz, identity, props.size, props.large, props.medium, props.small);
-    initDisabled(clazz, identity, props.disabled);
+    initSize(clazz, 'k-text-field', props.size, props.large, props.medium, props.small);
+    initDisabled(clazz, 'k-text-field', props.disabled);
 
     if (props.labelDirection && (props.row || props.column)) {
       throw Error('Error: labelDirection and row or column attributes cannot be duplicated.');
     }
-    if (props.labelDirection) { clazz.push(`${identity}--${props.labelDirection}`); }
-    if (props.column) { clazz.push(`${identity}--column`); }
-    if (props.row) { clazz.push(`${identity}--row`); }
+    if (props.labelDirection) { clazz.push(`k-text-field--${props.labelDirection}`); }
+    if (props.column) { clazz.push('k-text-field--column'); }
+    if (props.row) { clazz.push('k-text-field--row'); }
     if (!props.labelDirection && !props.column && !props.row) {
-      clazz.push(`${identity}--column`);
+      clazz.push('k-text-field--column');
     }
 
-    if (props.password) { clazz.push(`${identity}__input--password`); }
-    if (props.required) { clazz.push(`${identity}__input--required`); }
+    if (props.password) { clazz.push('k-text-field__input--password'); }
+    if (props.required) { clazz.push('k-text-field__input--required'); }
+    if (props.clearable) { clazz.push('k-text-field__input--clearable'); }
 
     return clazz.join(' ');
   }, [
@@ -67,13 +70,20 @@ const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>)
   }, [props.style, props.color]);
 
   const labelClass = useMemo(() => {
-    const clazz = [`${identity}__label__text`];
+    const clazz = [];
 
-    if (!props.label) { return clazz.join(' '); }
-    if (isFocus) { clazz.push(`${identity}__label__text--focus`); }
+    if (!props.label) { return ''; }
+    if (isFocus) { clazz.push('k-text-field__label__text--focus'); }
 
     return clazz.join(' ');
   }, [props.label, isFocus]);
+
+  const iconSize = useMemo(() => {
+    if (props.size === 'large' || props.large) { return 20; }
+    if (!props.size || props.size === 'medium' || props.medium) { return 18; }
+    if (props.size === 'small' || props.small) { return 16; }
+
+  }, []);
 
   // endregion
 
@@ -95,15 +105,29 @@ const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>)
     setIsFocus(false);
   }, [props.label]);
 
+  const onClear = useCallback(() => {
+    if (props.clearable && props.onChange) {
+      props.onChange('');
+    }
+  }, [props.clearable]);
+
+  const onPasswordShow = useCallback(() => {
+    setIsPasswdShow((prev) => !prev);
+  }, [props.password, isPasswdShow]);
+
   // endregion
 
 
   return (
-    <div className={rootClass} style={rootStyle} data-testid='k-text-field'>
-      <div className={`${identity}__label__container`}>
+    <div className={`k-text-field ${rootClass}`} style={rootStyle} data-testid='k-text-field'>
+      <div className='k-text-field__label__container'>
         {
           props.label && (
-            <label htmlFor={props.id ? props.id : uniqueId} className={labelClass} data-testid='k-text-field-label'>
+            <label
+                            htmlFor={props.id ? props.id : uniqueId}
+                            className={`k-text-field__label__text ${labelClass}`}
+                            data-testid='k-text-field-label'
+            >
               {props.label}
             </label>
           )
@@ -111,30 +135,58 @@ const KTextField = forwardRef((props: KTextFieldProps, ref: Ref<KTextFieldRefs>)
         {
           props.rightAction && (
             (!props.labelDirection && !props.row)
-                || (props.labelDirection === 'column' && !props.column)
-                || (!props.labelDirection && props.column)
+                        || (props.labelDirection === 'column' && !props.column)
+                        || (!props.labelDirection && props.column)
           ) && (
-            <div className={`${identity}__label__right-action`}>
+            <div className='k-text-field__label__right-action'>
               {props.rightAction}
             </div>
           )
         }
       </div>
-      <div className={`${identity}__wrap`}>
+      <div className='k-text-field__input__container'>
         <input
-            id={props.id ? props.id : uniqueId}
-            ref={inputRef}
-            className={`${identity}__input`}
-            type={props.password ? 'password' : 'input'}
-            value={props.value}
-            onChange={onChangeValue}
-            onFocus={onFocus}
-            onBlur={onblur}
-            disabled={props.disabled}
-            placeholder={props.placeholder}
-            maxLength={props.maxLength}
-            // aria-describedby='message' // FIXME: Error Message - 웹접근성
+                    id={props.id ? props.id : uniqueId}
+                    ref={inputRef}
+                    className='k-text-field__input'
+                    type={(props.password && !isPasswdShow) ? 'password' : 'input'}
+                    value={props.value}
+                    onChange={onChangeValue}
+                    onFocus={onFocus}
+                    onBlur={onblur}
+                    disabled={props.disabled}
+                    placeholder={props.placeholder}
+                    maxLength={props.maxLength}
+                    // aria-describedby='message' // FIXME: Error Message - 웹접근성
         />
+        {
+          props.password && (
+            isPasswdShow
+              ? (
+                <KIcon
+                    className='k-text-field__icon'
+                    icon='visibility_off'
+                    size={iconSize}
+                    clickable
+                    onClick={onPasswordShow}
+                />
+              )
+              : (
+                <KIcon
+                        className='k-text-field__icon'
+                        icon='visibility'
+                        size={iconSize}
+                        clickable
+                        onClick={onPasswordShow}
+                />
+              )
+          )
+        }
+        {
+          props.clearable && props.value && (
+            <KIcon className='k-text-field__icon' icon='close' size={iconSize} clickable onClick={onClear} />
+          )
+        }
       </div>
     </div>
   );

--- a/src/styles/components/text-field/KTextField.scss
+++ b/src/styles/components/text-field/KTextField.scss
@@ -43,7 +43,7 @@
         }
     }
 
-    .k-text-field__wrap {
+    .k-text-field__input__container {
         display: inline-flex;
         justify-content: center;
         align-items: center;
@@ -72,12 +72,16 @@
                 color: $k-placeholder-font-color;
             }
         }
+
+        .k-text-field__icon {
+            margin-left: $k-spacing-8;
+        }
     }
 
 
     .dark &.k-text-field--disabled, &.k-text-field--disabled {
 
-        .k-text-field__wrap {
+        .k-text-field__input__container {
             background: $k-white-disabled-color;
             cursor: not-allowed;
 
@@ -94,11 +98,12 @@
     // Type: Password
     &.k-text-field__input--password {
 
-        &.k-text-field--large .k-text-field__wrap > .k-text-field__input { letter-spacing: 6px; }
-        &.k-text-field--medium .k-text-field__wrap > .k-text-field__input { letter-spacing: 4px; }
-        &.k-text-field--small .k-text-field__wrap > .k-text-field__input { letter-spacing: 2px; }
+        &.k-text-field--large .k-text-field__input__container > .k-text-field__input { letter-spacing: 4px; }
+        &.k-text-field--medium .k-text-field__input__container > .k-text-field__input { letter-spacing: 2px; }
+        &.k-text-field--small .k-text-field__input__container > .k-text-field__input { letter-spacing: 1px; }
     }
 
+    // Type: Required
     &.k-text-field__input--required {
 
         .k-text-field__label__container {
@@ -110,6 +115,13 @@
         }
     }
 
+    // Type: Clearable
+    &.k-text-field__input--clearable {
+
+
+    }
+
+
     // Size
     &.k-text-field--large {
 
@@ -118,7 +130,7 @@
             .k-text-field__label__text { @include k-label-1; }
         }
 
-        .k-text-field__wrap {
+        .k-text-field__input__container {
             padding: $k-spacing-10 $k-spacing-16;
             .k-text-field__input { @include k-body-1; }
         }
@@ -130,7 +142,7 @@
             .k-text-field__label__text { @include k-label-2; }
         }
 
-        .k-text-field__wrap {
+        .k-text-field__input__container {
             padding: $k-spacing-8 $k-spacing-12;
             .k-text-field__input { @include k-body-2; }
         }
@@ -142,7 +154,7 @@
             .k-text-field__label__text { @include k-label-3; }
         }
 
-        .k-text-field__wrap {
+        .k-text-field__input__container {
             padding: $k-spacing-6 $k-spacing-8;
             .k-text-field__input { @include k-body-3; }
         }
@@ -168,7 +180,7 @@
         }
     }
 
-    .k-text-field__wrap {
+    .k-text-field__input__container {
         border: 1px solid $k-dark-mode-border-default-color;
         border-radius: $k-border-radius-default;
         background: $k-dark-mode-background;

--- a/stories/components/textfield/KTextField.stories.tsx
+++ b/stories/components/textfield/KTextField.stories.tsx
@@ -16,9 +16,9 @@ type Story = StoryObj<KTextFieldProps>
 
 const Template = (args: KTextFieldProps) => {
 
-    const [largeValue, setLargeValue] = useState('Large');
-    const [mediumValue, setMediumValue] = useState('Medium');
-    const [smallValue, setSmallValue] = useState('Small');
+    const [largeValue, setLargeValue] = useState('');
+    const [mediumValue, setMediumValue] = useState('');
+    const [smallValue, setSmallValue] = useState('');
 
     const RightAction = useMemo(() => {
         const style: CSSProperties = {fontSize: '12px', textDecoration: 'underline'};
@@ -28,43 +28,43 @@ const Template = (args: KTextFieldProps) => {
     return (
         <Container>
             <Item label={'Default TextField'}>
-                <KTextField {...args} large value={largeValue} placeholder={'Default TextField'} onChange={(v) => {setLargeValue(v);}}/>
-                <KTextField medium value={mediumValue} placeholder={'Default TextField'} onChange={(v) => {setMediumValue(v);}}/>
-                <KTextField small value={smallValue} placeholder={'Default TextField'} onChange={(v) => {setSmallValue(v);}}/>
+                <KTextField {...args} large value={largeValue} placeholder={'Large'} onChange={(v) => {setLargeValue(v);}}/>
+                <KTextField medium value={mediumValue} placeholder={'Medium'} onChange={(v) => {setMediumValue(v);}}/>
+                <KTextField small value={smallValue} placeholder={'Small'} onChange={(v) => {setSmallValue(v);}}/>
             </Item>
             <Item label={'Password / required / right-action'}>
-                <KTextField large password required labelDirection={'column'}  label={'비밀번호'} rightAction={RightAction} value={largeValue}
+                <KTextField password labelDirection={'column'} label={'비밀번호'} value={largeValue}
                             onChange={(v) => {setLargeValue(v);}}/>
-                <KTextField medium password required column label={'비밀번호'} rightAction={RightAction} value={mediumValue}
+                <KTextField  password required column label={'비밀번호'} value={mediumValue}
                             onChange={(v) => {setMediumValue(v);}}/>
-                <KTextField small password required label={'비밀번호'} rightAction={RightAction} value={smallValue}
+                <KTextField  password required label={'비밀번호'} rightAction={RightAction} value={smallValue}
                             onChange={(v) => {setSmallValue(v);}}/>
             </Item>
-            <Item label={'Label - Direction: Column'}>
-                <KTextField label={'아이디'} column placeholder={'Label - Direction: Column'} large value={largeValue}
+            <Item label={'Label(Direction: Column)'}>
+                <KTextField label={'Column'} column placeholder={'Column'} large value={largeValue}
                             onChange={(v) => {setLargeValue(v);}}/>
-                <KTextField label={'아이디'} column placeholder={'Label - Direction: Column'} medium value={mediumValue}
+                <KTextField label={'Column'} column placeholder={'Column'} medium value={mediumValue}
                             onChange={(v) => {setMediumValue(v);}}/>
-                <KTextField label={'아이디'} column placeholder={'Label - Direction: Column'} small value={smallValue}
+                <KTextField label={'Column'} column placeholder={'Column'} small value={smallValue}
                             onChange={(v) => {setSmallValue(v);}}/>
             </Item>
-            <Item label={'Label - Direction: Row'}>
-                <KTextField label={'아이디'} row placeholder={'Label - Direction: Row'} large value={largeValue}
+            <Item label={'Label(Direction: Row)'}>
+                <KTextField label={'Row'} row placeholder={'Row'} large value={largeValue}
                             onChange={(v) => {setLargeValue(v);}} rightAction={RightAction}/>
-                <KTextField label={'아이디'} labelDirection={'row'} placeholder={'Label - Direction: Row'} medium value={mediumValue}
+                <KTextField label={'Row'} labelDirection={'row'} placeholder={'Row'} medium value={mediumValue}
                             onChange={(v) => {setMediumValue(v);}} rightAction={RightAction}/>
-                <KTextField label={'아이디'} row placeholder={'Label - Direction: Row'} small value={smallValue}
+                <KTextField label={'Row'} row placeholder={'Row'} small value={smallValue}
                             onChange={(v) => {setSmallValue(v);}} maxLength={10}/>
             </Item>
-            <Item label={'Placeholder'}>
-                <KTextField label={'아이디'} large placeholder={'아이디를 입력해주세요.'} value={''} />
-                <KTextField label={'아이디'} medium placeholder={'아이디를 입력해주세요.'} value={''} />
-                <KTextField label={'아이디'} small placeholder={'아이디를 입력해주세요.'} value={''} />
-            </Item>
             <Item label={'Disabled'}>
-                <KTextField label={'아이디'} large value={largeValue} disabled onChange={(v) => {setLargeValue(v);}}/>
-                <KTextField label={'아이디'} medium value={mediumValue} disabled onChange={(v) => {setMediumValue(v);}}/>
-                <KTextField label={'아이디'} small value={smallValue} disabled onChange={(v) => {setSmallValue(v);}}/>
+                <KTextField label={'아이디'} large value={'Disabled'} disabled />
+                <KTextField label={'아이디'} medium value={'Disabled'} disabled />
+                <KTextField label={'아이디'} small value={'Disabled'} disabled />
+            </Item>
+            <Item label={'Clearable'}>
+                <KTextField placeholder={'Clearable'} clearable value={largeValue} onChange={(v) => {setLargeValue(v);}}/>
+                <KTextField placeholder={'Clearable'} value={mediumValue}  onChange={(v) => {setMediumValue(v);}}/>
+                <KTextField placeholder={'Clearable'} value={smallValue}  onChange={(v) => {setSmallValue(v);}}/>
             </Item>
         </Container>
     );

--- a/stories/components/textfield/KTextField.stories.tsx
+++ b/stories/components/textfield/KTextField.stories.tsx
@@ -62,9 +62,9 @@ const Template = (args: KTextFieldProps) => {
                 <KTextField label={'아이디'} small value={'Disabled'} disabled />
             </Item>
             <Item label={'Clearable'}>
-                <KTextField placeholder={'Clearable'} clearable value={largeValue} onChange={(v) => {setLargeValue(v);}}/>
-                <KTextField placeholder={'Clearable'} value={mediumValue}  onChange={(v) => {setMediumValue(v);}}/>
-                <KTextField placeholder={'Clearable'} value={smallValue}  onChange={(v) => {setSmallValue(v);}}/>
+                <KTextField large placeholder={'Clearable'} clearable value={largeValue} onChange={(v) => {setLargeValue(v);}}/>
+                <KTextField placeholder={'Clearable'} clearable value={mediumValue}  onChange={(v) => {setMediumValue(v);}}/>
+                <KTextField small placeholder={'Clearable'} clearable value={smallValue}  onChange={(v) => {setSmallValue(v);}}/>
             </Item>
         </Container>
     );


### PR DESCRIPTION
- `<KIcon />` 웹접근성 처리
  - `onClick` 이벤트가 있을 경우 `role='button'`, 아닌경우 `img` 
  - 테스트 코드 작성
- `<KTextField />` `clearable`, `password` prop이 있을 경우 우측 아이콘 삽입
  - `password` 타입인 경우 `visibility` 토글 적용
  - 테스트 코드 작성

![image](https://github.com/macjjuni/kku-ui/assets/38034518/3d95ff21-9184-420a-9b21-2b88c604ef19)
